### PR TITLE
update versioning

### DIFF
--- a/megadesk-core/pom.xml
+++ b/megadesk-core/pom.xml
@@ -11,6 +11,6 @@
     <parent>
         <groupId>com.liveramp</groupId>
         <artifactId>megadesk</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 </project>

--- a/megadesk-curator/pom.xml
+++ b/megadesk-curator/pom.xml
@@ -11,20 +11,14 @@
     <parent>
         <groupId>com.liveramp</groupId>
         <artifactId>megadesk</artifactId>
-        <version>0.1-SNAPSHOT</version>
+        <version>1.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>com.liveramp.megadesk</groupId>
             <artifactId>megadesk-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>megadesk-recipes</artifactId>
-            <version>${project.version}</version>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -37,6 +31,11 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-test</artifactId>
             <version>2.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.liveramp.megadesk</groupId>
+            <artifactId>megadesk-recipes</artifactId>
+            <version>1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/megadesk-recipes/pom.xml
+++ b/megadesk-recipes/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.liveramp</groupId>
     <artifactId>megadesk</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>1.0-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 
   <artifactId>megadesk</artifactId>
-  <version>0.1-SNAPSHOT</version>
+  <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
1. Change the version of megadesk to `1.0-SNAPSHOT` instead of `0.1-SNAPSHOT`. I'm pretty sure this is a typo (even the readme refers to `1.0-SNAPSHOT`).
2. Use hard coded group ids and versions instead of loading from project parameters. I've had occasional problems with resolving megadesk-curator dependencies in IntelliJ and this seems to fix the problem. 

@bpodgursky 
